### PR TITLE
Added optional GDPR usage footer

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -375,6 +375,7 @@
 /// - body-font (array): Font(s) for body text
 /// - paper-size (string): Paper size
 /// - side-width (length): Sidebar width
+/// - gdpr (boolean): Add GDPR data usage in the footer
 /// - body (content): Main content of the CV
 #let cv(
   author: (:),
@@ -386,6 +387,7 @@
   body-font: ("Noto Sans", "Roboto"),
   paper-size: "us-letter",
   side-width: 4cm,
+  gdpr: false,
   body,
 ) = {
   context {
@@ -420,6 +422,7 @@
       #grid(
         columns: (side-width, 1fr),
         align: center,
+        gutter: 2mm,
         inset: (col, _) => {
           if col == 0 {
             (right: 4mm)
@@ -433,6 +436,12 @@
         [
           #author.firstname #author.lastname CV #box(inset: (x: 3pt), sym.dot.c) #text(date)
         ],
+        [],
+        if gdpr {
+          [
+            I authorise the processing of personal data contained within my CV, according to GDPR (EU) 2016/679, Article 6.1(a).
+          ]
+        }
       )
     ],
   )

--- a/template/cv.typ
+++ b/template/cv.typ
@@ -29,6 +29,7 @@
   // body-font: ("Noto Sans", "Roboto"),
   // paper-size: "us-letter",
   // side-width: 4cm,
+  // gdpr: false,
 )
 
 #side[


### PR DESCRIPTION
Hi there,
first of all, thanks for making this CV template public!
While I was personalizing it, I've added the option to add a GDPR clause at the footer of the CV (disabled by default).
This is not really thought to be merge-able as is since a new version of the lib would be needed to be imported.
This created a kind of "chicken-and-egg" situation, making this PR draft-ish.

Let me know if this interests you and/or how to proceed.
S.G.