### PR TITLE
Fix for non flat accent colors + Custom footer support

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -440,7 +440,7 @@
           ],
         )
       ]
-    } else [#footer],
+    } else { footer },
   )
 
   set par(spacing: 0.75em, justify: true)

--- a/lib.typ
+++ b/lib.typ
@@ -378,6 +378,7 @@
 /// - body-font (array): Font(s) for body text
 /// - paper-size (string): Paper size
 /// - side-width (length): Sidebar width
+/// - footer (content): Optional custom footer
 /// - body (content): Main content of the CV
 #let cv(
   author: (:),

--- a/lib.typ
+++ b/lib.typ
@@ -62,7 +62,7 @@
     let levels = range(max-level).map(l => box(
       height: 3.5pt,
       width: 100%,
-      fill: if (l <= level) { _accent-color },
+      fill: if (l < level) { _accent-color },
       stroke: _accent-color + 0.75pt,
     ))
     grid(

--- a/lib.typ
+++ b/lib.typ
@@ -389,6 +389,7 @@
   body-font: ("Noto Sans", "Roboto"),
   paper-size: "us-letter",
   side-width: 4cm,
+  footer: auto,
   body,
 ) = {
   context {
@@ -417,27 +418,29 @@
   set page(
     paper: paper-size,
     margin: (left: 12mm, right: 12mm, top: 10mm, bottom: 12mm),
-    footer: [
-      #set text(size: 0.7em, fill: font-color.lighten(50%))
+    footer: if footer == auto {
+      [
+        #set text(size: 0.7em, fill: font-color.lighten(50%))
 
-      #grid(
-        columns: (side-width, 1fr),
-        align: center,
-        inset: (col, _) => {
-          if col == 0 {
-            (right: 4mm)
-          } else {
-            (left: 4mm)
-          }
-        },
-        [
-          #context counter(page).display("1 / 1", both: true)
-        ],
-        [
-          #author.firstname #author.lastname CV #box(inset: (x: 3pt), sym.dot.c) #text(date)
-        ],
-      )
-    ],
+        #grid(
+          columns: (side-width, 1fr),
+          align: center,
+          inset: (col, _) => {
+            if col == 0 {
+              (right: 4mm)
+            } else {
+              (left: 4mm)
+            }
+          },
+          [
+            #context counter(page).display("1 / 1", both: true)
+          ],
+          [
+            #author.firstname #author.lastname CV #box(inset: (x: 3pt), sym.dot.c) #text(date)
+          ],
+        )
+      ]
+    } else [#footer],
   )
 
   set par(spacing: 0.75em, justify: true)

--- a/lib.typ
+++ b/lib.typ
@@ -59,11 +59,14 @@
       accent-color
     }
     let col-width = (width - 2pt * (max-level - 1)) / max-level
-    let levels = (box(height: 3.5pt, width: 100%, fill: _accent-color),) * level
-
+    let levels = range(max-level).map(l => box(
+      height: 3.5pt,
+      width: 100%,
+      fill: if (l <= level) { _accent-color },
+      stroke: _accent-color + 0.75pt,
+    ))
     grid(
       columns: (col-width,) * max-level,
-      stroke: _accent-color + 0.75pt,
       gutter: 2pt,
       ..levels
     )


### PR DESCRIPTION
Hi, thanks for the template.

I made these two edits for my personal use, I think it may be useful for others.

Firstly, when using non flat colors for the accent color (like a gradient), the stroke parameter of grids is not ideal, as each separate line will be rendered differently.
The fix uses the stroke parameter from each box.

Old :
![image](https://github.com/user-attachments/assets/b992faf4-b155-4915-baf7-3dfbd4c10a00)

New : 
![image](https://github.com/user-attachments/assets/aeef0200-86e7-495e-975d-d49aa66bec84)


Secondly, one might customize the footer content, for instance to remove page count (if the CV is only 1 page long).
The base behavior has been kept if no custom parameter is given.