### PR TITLE
feat: Make body text font size user-configurable

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -4,6 +4,14 @@
 #let __st-theme = state("theme")
 #let __st-author = state("author")
 
+// ---- Constants ----
+/// Scaling factor to apply to the body font size to obtain the side-content font size.
+#let SIDE_CONTENT_FONT_SIZE_SCALE = 0.72
+/// Scaling factor to apply to the body font size to obtain the item-pills font size.
+#let ITEM_PILLS_FONT_SIZE_SCALE = 0.85
+/// Scaling factor to apply to the body font size to obtain the footer font size.
+#let FOOTER_FONT_SIZE_SCALE = 0.7
+
 
 // ---- Icon & Visual Helpers ----
 
@@ -55,7 +63,7 @@
 
     block(width: 100%, height: size, radius: 0.6em, align(horizon, [
       #__fa-icon-outline(icon, size: size)
-      #box(inset: (left: 1pt), height: 100%, link(url)[#display])
+      #box(inset: (left: 0.2em), height: 100%, link(url)[#display])
     ]))
   }
 )
@@ -86,18 +94,21 @@
     } else {
       accent-color
     }
-    let col-width = (width - 2pt * (max-level - 1)) / max-level
+    let col-width = (
+      (width - (0.2em / SIDE_CONTENT_FONT_SIZE_SCALE) * (max-level - 1))
+        / max-level
+    )
     let levels = range(max-level).map(l => box(
-      height: 3.5pt,
+      height: 0.35em / SIDE_CONTENT_FONT_SIZE_SCALE,
       width: 100%,
       fill: if (l < level) {
         _accent-color
       },
-      stroke: _accent-color + 0.75pt,
+      stroke: _accent-color + 0.075em / SIDE_CONTENT_FONT_SIZE_SCALE,
     ))
     grid(
       columns: (col-width,) * max-level,
-      gutter: 2pt,
+      gutter: 0.2em / SIDE_CONTENT_FONT_SIZE_SCALE,
       ..levels
     )
   }
@@ -117,14 +128,17 @@
   context {
     let theme = __st-theme.final()
 
-    set text(size: 0.85em, spacing: 0.5em)
+    set text(size: ITEM_PILLS_FONT_SIZE_SCALE * 1em, spacing: 0.5em)
     set par(justify: justify)
 
     block(
       items
         .map(item => box(
-          inset: (x: 3pt, y: 3pt),
-          stroke: theme.accent-color + 0.5pt,
+          inset: (
+            x: 0.45em / ITEM_PILLS_FONT_SIZE_SCALE,
+            y: 0.45em / ITEM_PILLS_FONT_SIZE_SCALE,
+          ),
+          stroke: theme.accent-color + 0.08em / ITEM_PILLS_FONT_SIZE_SCALE,
           item,
         ))
         .join(" "),
@@ -173,7 +187,7 @@
     #let theme = __st-theme.final()
 
     #grid(
-      columns: (2cm, auto),
+      columns: (5.7em, auto),
       align: (right, left),
       column-gutter: .8em,
       [
@@ -449,7 +463,7 @@
 
     for year in publications-by-year.keys().sorted().rev() {
       grid(
-        columns: (2cm, auto),
+        columns: (5.7em, auto),
         align: (right, left),
         column-gutter: .8em,
         [
@@ -551,25 +565,36 @@
     }
   )
 
-  set text(font: body-font, size: body-font-size, weight: "light", fill: font-color)
+  set text(
+    font: body-font,
+    size: body-font-size,
+    weight: "light",
+    fill: font-color,
+  )
 
   set page(
     paper: paper-size,
     margin: (left: 12mm, right: 12mm, top: 10mm, bottom: 12mm),
     footer: if footer == auto {
       [
-        #set text(size: 0.7em, fill: font-color.lighten(50%))
+        #set text(
+          size: FOOTER_FONT_SIZE_SCALE * 1em,
+          fill: font-color.lighten(50%),
+        )
 
         #grid(
           columns: (side-width, 1fr),
           align: center,
-          gutter: 12mm,
+          gutter: 1.2em / FOOTER_FONT_SIZE_SCALE,
           inset: 0pt,
           [
             #context counter(page).display("1 / 1", both: true)
           ],
           [
-            #author.firstname #author.lastname CV #box(inset: (x: 3pt), sym.dot.c) #text(date)
+            #author.firstname #author.lastname CV #box(
+              inset: (x: 0.3em / FOOTER_FONT_SIZE_SCALE),
+              sym.dot.c,
+            ) #text(date)
           ],
 
           [],
@@ -602,7 +627,7 @@
       )[
         #align(center)[
           #let position = if type(author.position) == array {
-            author.position.join(box(inset: (x: 5pt), sym.dot.c))
+            author.position.join(box(inset: (x: 0.5em), sym.dot.c))
           } else {
             author.position
           }
@@ -628,7 +653,7 @@
   }
 
   let side-content = context {
-    set text(size: 0.72em)
+    set text(size: SIDE_CONTENT_FONT_SIZE_SCALE * 1em)
 
     show heading.where(level: 1): it => block(width: 100%, above: 2em)[
       #set text(font: heading-font, fill: accent-color, weight: "regular")
@@ -636,7 +661,12 @@
       #grid(
         columns: (0pt, 1fr),
         align: horizon,
-        box(fill: accent-color, width: -4pt, height: 12pt, outset: (left: 6pt)),
+        box(
+          fill: accent-color,
+          width: -0.29em / SIDE_CONTENT_FONT_SIZE_SCALE,
+          height: 0.86em / SIDE_CONTENT_FONT_SIZE_SCALE,
+          outset: (left: 0.43em / SIDE_CONTENT_FONT_SIZE_SCALE),
+        ),
         it.body,
       )
     ]
@@ -644,7 +674,7 @@
     if profile-picture != none {
       block(
         clip: true,
-        stroke: accent-color + 1pt,
+        stroke: accent-color + 0.1em / SIDE_CONTENT_FONT_SIZE_SCALE,
         radius: side-width / 2,
         width: 100%,
         profile-picture,
@@ -673,20 +703,20 @@
 
   head
 
-  v(2mm)
+  v(0.56em)
 
   grid(
-    columns: (side-width + 6mm, auto),
+    columns: (side-width + 1.68em, auto),
     align: (left, left),
     inset: (col, _) => {
       if col == 0 {
-        (right: 6mm, y: 1mm)
+        (right: 1.68em, y: 0.28em)
       } else {
-        (left: 6mm, y: 1mm)
+        (left: 1.68em, y: 0.28em)
       }
     },
     side-content,
-    grid.vline(stroke: luma(180) + 0.5pt),
+    grid.vline(stroke: luma(180) + 0.05em),
     body-content,
   )
 }

--- a/lib.typ
+++ b/lib.typ
@@ -26,6 +26,8 @@
 #let LEVEL_BAR_GAP_SIZE = 2pt
 /// Height of the box of each individual section in the level bar
 #let LEVEL_BAR_BOX_HEIGHT = 3.5pt
+/// Width of the left column in an `entry()` or `publication()`
+#let ENTRY_LEFT_COLUMN_WIDTH = 5.7em
 
 // ---- Utility ----
 /// Calculate/scale the length of stroke elements, as strokes are visual
@@ -206,7 +208,7 @@
     #let theme = __st-theme.final()
 
     #grid(
-      columns: (5.7em, auto),
+      columns: (ENTRY_LEFT_COLUMN_WIDTH, auto),
       align: (right, left),
       column-gutter: .8em,
       [
@@ -482,7 +484,7 @@
 
     for year in publications-by-year.keys().sorted().rev() {
       grid(
-        columns: (5.7em, auto),
+        columns: (ENTRY_LEFT_COLUMN_WIDTH, auto),
         align: (right, left),
         column-gutter: .8em,
         [

--- a/lib.typ
+++ b/lib.typ
@@ -727,13 +727,13 @@
   v(HEADER_BODY_GAP)
 
   grid(
-    columns: (side-width + 1.68em, auto),
+    columns: (side-width + (HORIZONTAL_PAGE_MARGIN / 2), auto),
     align: (left, left),
     inset: (col, _) => {
       if col == 0 {
-        (right: 1.68em, y: 0.28em)
+        (right: (HORIZONTAL_PAGE_MARGIN / 2), y: 1mm)
       } else {
-        (left: 1.68em, y: 0.28em)
+        (left: (HORIZONTAL_PAGE_MARGIN / 2), y: 1mm)
       }
     },
     side-content,

--- a/lib.typ
+++ b/lib.typ
@@ -11,6 +11,17 @@
 #let ITEM_PILLS_FONT_SIZE_SCALE = 0.85
 /// Scaling factor to apply to the body font size to obtain the footer font size.
 #let FOOTER_FONT_SIZE_SCALE = 0.7
+/// Gap between the header (colored block at the top) and body
+#let HEADER_BODY_GAP = 2mm
+/// Horizontal page margin
+#let HORIZONTAL_PAGE_MARGIN = 12mm
+/// All page margins, defined explicitly
+#let PAGE_MARGIN = (
+  left: HORIZONTAL_PAGE_MARGIN,
+  right: HORIZONTAL_PAGE_MARGIN,
+  top: HORIZONTAL_PAGE_MARGIN - HEADER_BODY_GAP,
+  bottom: HORIZONTAL_PAGE_MARGIN,
+)
 
 
 // ---- Icon & Visual Helpers ----
@@ -574,7 +585,7 @@
 
   set page(
     paper: paper-size,
-    margin: (left: 12mm, right: 12mm, top: 10mm, bottom: 12mm),
+    margin: PAGE_MARGIN,
     footer: if footer == auto {
       [
         #set text(
@@ -585,7 +596,7 @@
         #grid(
           columns: (side-width, 1fr),
           align: center,
-          gutter: 1.2em / FOOTER_FONT_SIZE_SCALE,
+          gutter: HORIZONTAL_PAGE_MARGIN,
           inset: 0pt,
           [
             #context counter(page).display("1 / 1", both: true)
@@ -703,7 +714,7 @@
 
   head
 
-  v(0.56em)
+  v(HEADER_BODY_GAP)
 
   grid(
     columns: (side-width + 1.68em, auto),

--- a/lib.typ
+++ b/lib.typ
@@ -22,6 +22,10 @@
   top: HORIZONTAL_PAGE_MARGIN - HEADER_BODY_GAP,
   bottom: HORIZONTAL_PAGE_MARGIN,
 )
+/// Length of the gap between individual sections of the level bar
+#let LEVEL_BAR_GAP_SIZE = 2pt
+/// Height of the box of each individual section in the level bar
+#let LEVEL_BAR_BOX_HEIGHT = 3.5pt
 
 // ---- Utility ----
 /// Calculate/scale the length of stroke elements, as strokes are visual
@@ -112,12 +116,9 @@
     } else {
       accent-color
     }
-    let col-width = (
-      (width - (0.2em / SIDE_CONTENT_FONT_SIZE_SCALE) * (max-level - 1))
-        / max-level
-    )
+    let col-width = (width - LEVEL_BAR_GAP_SIZE * (max-level - 1)) / max-level
     let levels = range(max-level).map(l => box(
-      height: 0.35em / SIDE_CONTENT_FONT_SIZE_SCALE,
+      height: LEVEL_BAR_BOX_HEIGHT,
       width: 100%,
       fill: if (l < level) {
         _accent-color
@@ -126,7 +127,7 @@
     ))
     grid(
       columns: (col-width,) * max-level,
-      gutter: 0.2em / SIDE_CONTENT_FONT_SIZE_SCALE,
+      gutter: LEVEL_BAR_GAP_SIZE,
       ..levels
     )
   }

--- a/lib.typ
+++ b/lib.typ
@@ -23,6 +23,13 @@
   bottom: HORIZONTAL_PAGE_MARGIN,
 )
 
+// ---- Utility ----
+/// Calculate/scale the length of stroke elements, as strokes are visual
+/// elements and should have a constant length.
+///
+/// -> length
+#let __stroke_length(x) = x * 1pt
+
 
 // ---- Icon & Visual Helpers ----
 
@@ -115,7 +122,7 @@
       fill: if (l < level) {
         _accent-color
       },
-      stroke: _accent-color + 0.075em / SIDE_CONTENT_FONT_SIZE_SCALE,
+      stroke: _accent-color + __stroke_length(0.75),
     ))
     grid(
       columns: (col-width,) * max-level,
@@ -149,7 +156,7 @@
             x: 0.45em / ITEM_PILLS_FONT_SIZE_SCALE,
             y: 0.45em / ITEM_PILLS_FONT_SIZE_SCALE,
           ),
-          stroke: theme.accent-color + 0.08em / ITEM_PILLS_FONT_SIZE_SCALE,
+          stroke: theme.accent-color + __stroke_length(0.5),
           item,
         ))
         .join(" "),
@@ -685,7 +692,7 @@
     if profile-picture != none {
       block(
         clip: true,
-        stroke: accent-color + 0.1em / SIDE_CONTENT_FONT_SIZE_SCALE,
+        stroke: accent-color + __stroke_length(1),
         radius: side-width / 2,
         width: 100%,
         profile-picture,
@@ -727,7 +734,7 @@
       }
     },
     side-content,
-    grid.vline(stroke: luma(180) + 0.05em),
+    grid.vline(stroke: luma(180) + __stroke_length(0.5)),
     body-content,
   )
 }

--- a/lib.typ
+++ b/lib.typ
@@ -503,6 +503,9 @@
   /// Font(s) for body text
   /// -> array
   body-font: ("Noto Sans", "Roboto"),
+  /// Font size for body text
+  /// -> length
+  body-font-size: 10pt,
   /// Paper size
   /// -> string
   paper-size: "us-letter",
@@ -548,7 +551,7 @@
     }
   )
 
-  set text(font: body-font, size: 10pt, weight: "light", fill: font-color)
+  set text(font: body-font, size: body-font-size, weight: "light", fill: font-color)
 
   set page(
     paper: paper-size,


### PR DESCRIPTION
Adds another parameter to the `cv` template function that controls the body text font size. This allows users to increase font size because the default can be hard to read when presented on A4 paper for some people at least.

As part of this feature I have gone ahead and eliminated (hopefully?) all fixed-size lengths from the template code, too. All lengths are now properly calculated in relation to the text font size. As there are many nested function calls that each reduce font size at some point, not all of the numbers I ended up with have a common "conversion" ratio.

The end result is that now one can increase the font size to e.g. 12 pt and everything in the resulting document will scale accordingly by a factor of 1.2 compared to the previous default of 10 pt. Those results are not exact, though. I verified this by building a PDF from latest `main` and this branch and compared their "PDF source" as text. That method isn't exactly accurate and I can't comment on the binary changes, but everything that looks like coordinates of some sort was off by a small amount only. That is to be expected since I didn't round the relative lengths to arbitrary precision in order to obtain a "close" approximation. I hope that's okay though.

I did a lot of visual comparisons and, as far as I can tell, the deviations are minimal. Here is a screenshot of the result, built with 12 pt body font size configured (The fonts are wrong, I know, this was only for testing):

<img width="1000" height="1088" alt="image" src="https://github.com/user-attachments/assets/3894cb55-605f-4323-b907-d52128b26b5f" />
