### PR TITLE
feat: Add Matrix contact icon

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -334,6 +334,13 @@
       )
     }
 
+    #if "matrix" in author {
+      contact-items += (
+        [#v(-0.2em) #fa-icon("comment", fill: accent-color)],
+        link("https://matrix.to/#/" + author.matrix, author.matrix),
+      )
+    }
+
     #if "phone" in author {
       contact-items += (
         [#v(-0.2em) #fa-icon("mobile-screen", fill: accent-color)],

--- a/template/cv.typ
+++ b/template/cv.typ
@@ -10,6 +10,7 @@
     email: "doc.brown@hillvalley.edu",
     address: [1640 Riverside Drive\ Hill Valley\ California, USA],
     phone: "(555) 121-1955",
+    // matrix: "",
     position: ("Inventor", "Theoretical Physicist"),
     website: "https://docbrownlabs.com",
     twitter: "docbrown1955",


### PR DESCRIPTION
Adds an optional contact entry for [Matrix](https://matrix.org/) using https://github.com/matrix-org/matrix.to