### PR TITLE
Improve publications appearance

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -409,7 +409,7 @@
         if first_names_str == "" {
           [#last_name]
         } else {
-          [#last_name, #joined_initials]
+          [#joined_initials #last_name]
         }
       }
 
@@ -421,18 +421,18 @@
 
       if i < max-authors - 1 and i < pub.author.len() - 1 {
         if i == pub.author.len() - 2 {
-          [ and ]
+          [, and ]
         } else {
           [, ]
         }
       }
     } else if i == max-authors {
-      [_ et al_]
+      [, _et al_]
       break
     }
   }
 
-  [. #pub.title.]
+  [, "#pub.title.replace(regex("[{}]"), "")",]
 
   let parent = pub.parent
 
@@ -440,23 +440,29 @@
     [ in ]
   }
 
-  [ #text(style: "italic", parent.title)]
+  [ _#parent.title.replace(regex("[{}]"), "")_]
 
   if "volume" in parent and parent.volume != none {
-    [ #text(style: "italic", str(parent.volume)), ]
+    [ _#(parent.volume)_]
   }
 
-  [ #pub.at("page-range", default: "")]
+  if "issue" in parent and parent.issue != none {
+    [_(#parent.issue)_]
+  }
+
+  if "page-range" in pub and pub.page-range != none {
+    [_:#(pub.page-range)_]
+  }
 
   if "date" in pub {
-    [ (#pub.date).]
+    [, #str(pub.date).split("-").at(0)]
   }
 
   if "serial-number" in pub and "doi" in pub.serial-number {
-    [
-      doi: #link("https://doi.org/" + pub.serial-number.doi)[#text(style: "italic", str(pub.serial-number.doi))]
-    ]
+    [, doi: #link("https://doi.org/" + pub.serial-number.doi)[_#(pub.serial-number.doi)_]]
   }
+
+  [.]
 }
 
 /// Displays publications grouped by year from a Hayagriva YAML file.
@@ -481,7 +487,7 @@
     set block(above: 0.7em, width: 100%)
 
     for pub in publication-data {
-      let year = str(pub.at("date", default: ""))
+      let year = str(pub.at("date", default: "")).split("-").at(0)
 
       if year == "" {
         continue


### PR DESCRIPTION
Hi,

thank you for this nice CV template! When using it I noticed that publications appearance was not perfect in some cases. In particular, [formattable strings](https://github.com/typst/hayagriva/blob/main/docs/file-format.md#formattable-string) in titles are not supported and dates are assumed to be just years, but often a month is also specified. These two conditions happened when I exported from Zotero a bibtex file and then I converted it to the YAML format using hayagriva cli.

This PR fixes these two bugs and tries to improve the overall appearance of the listing with the following changes:
- order of initials and last name of authors is reversed to avoid the double point on last author as it was before
- comma is used instead of point as separator
- quotes are used for the title
- issue is also showed if present
- a final dot is added

Here is an example showing a modified version of the template in which the bugs are simulated.

Before:
<img width="952" height="509" alt="immagine" src="https://github.com/user-attachments/assets/2b98a999-5cb8-4071-a400-0a67c51ac05e" />

After:
<img width="937" height="506" alt="immagine" src="https://github.com/user-attachments/assets/2cb61a9c-5a2e-43d6-a19d-45858b8df63e" />

I am not sure about the reference style, I tried to keep the old one as mush as possible, so feel free to change it.
