### PR TITLE
Add support for custom contact items (similar to `custom-links`)

### DIFF
--- a/src/components.typ
+++ b/src/components.typ
@@ -356,6 +356,25 @@
     }
   }
 
+  if "custom-contact" in author {
+    for item in author.custom-contact {
+      let icon-cell = if "icon-name" in item and item.icon-name != none {
+        [#v(-0.2em) #fa-icon(item.icon-name, fill: accent-color)]
+      } else {
+        []
+      }
+      let content = if "url" in item and item.url != none {
+        link(item.url, item.label)
+      } else {
+        item.label
+      }
+      contact-items += (
+        icon-cell,
+        content,
+      )
+    }
+  }
+
   if contact-items.len() > 0 {
     table(
       columns: (1em, 1fr),


### PR DESCRIPTION
There are situations where it would be helpful to add additional items to the contact info, for example one might want to add the birthday in the same style.

```typst
custom-contact: (
  (
    icon-name: "cake", // Font Awesome icon name
    label: "01.01.2042",
  ),
),